### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
     @items = Item.includes(:user).order('created_at DESC')
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
+    @items = Item.all
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all
+    @items = Item.includes(:user).order('created_at DESC')
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def create

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,20 +6,22 @@ class Item < ApplicationRecord
   belongs_to :shipping_fee
   belongs_to :shipping_prefecture
 
-  validates :category_id,:condition_id,:shipping_days_id,:shipping_fee_id,:shipping_prefecture_id, numericality: { other_than: 1 } 
+  validates :category_id, :condition_id, :shipping_days_id, :shipping_fee_id, :shipping_prefecture_id,
+            numericality: { other_than: 1 }
   belongs_to :user
   with_options presence: true do
     validates :title
     validates :explanation
     validates :category_id
-    validates :condition_id 
+    validates :condition_id
     validates :shipping_fee_id
     validates :shipping_prefecture_id
     validates :shipping_days_id
     validates :price
     validates :image
   end
-  validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: "is out of setting range"}
-  validates :price, format:{ with: /\A[0-9]+\z/, message: 'It is invalid. Price includes double-byte numbers' }
+  validates :price,
+            numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range' }
+  validates :price, format: { with: /\A[0-9]+\z/, message: 'It is invalid. Price includes double-byte numbers' }
   has_one_attached :image
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -125,14 +125,12 @@
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
-
+    <% if @items.present? %>
      <% @items.each do |item| %>
-      <% if item.present? %>
        <li class='list'>
         <%= link_to "#" do %>
          <div class='item-img-content'>
            <%= image_tag item.image, class: "item-img" %>
-
           <%# 商品が売れていればsold outを表示しましょう %>
            <%#if item.sold.present? %>
             <div class='sold-out'>
@@ -140,7 +138,6 @@
             </div>
            <%#end %>
           <%# //商品が売れていればsold outを表示しましょう %>
-
          </div>
          <div class='item-info'>
           <h3 class='item-name'>
@@ -155,10 +152,9 @@
           </div>
          </div>
         <% end %>
+      <% end %>
        </li>
       <% else %>
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
        <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -173,13 +169,10 @@
               <span class='star-count'>0</span>
             </div>
           </div>
-        </div>
+         </div>
          <% end %>
         </li>
-      <% end %>
     <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,24 +127,27 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# if item.sold.present? %>
+           <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+           </div>
+          <% #end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee_id.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -152,6 +155,7 @@
           </div>
         </div>
         <% end %>
+      <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,42 +126,40 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
      <% @items.each do |item| %>
-      <li class='list'>
+      <% if item.present? %>
+       <li class='list'>
         <%= link_to "#" do %>
-        <div class='item-img-content'>
-          <%= image_tag item.image, class: "item-img" %>
+         <div class='item-img-content'>
+           <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-          <%# if item.sold.present? %>
-           <div class='sold-out'>
-            <span>Sold Out!!</span>
-           </div>
-          <% #end %>
+           <%#if item.sold.present? %>
+            <div class='sold-out'>
+              <span>Sold Out!!</span>
+            </div>
+           <%#end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
-        </div>
-        <div class='item-info'>
+         </div>
+         <div class='item-info'>
           <h3 class='item-name'>
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_fee_id.name %></span>
+            <span><%= item.price %>円<br><%= item.shipping_fee.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
-        </div>
+         </div>
         <% end %>
-      <% end %>
-      </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
+       </li>
+      <% else %>
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
+       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
         <div class='item-info'>
@@ -176,8 +174,10 @@
             </div>
           </div>
         </div>
-        <% end %>
-      </li>
+         <% end %>
+        </li>
+      <% end %>
+    <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
     </ul>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -36,57 +36,57 @@ RSpec.describe Item, type: :model do
       it 'category_idがない場合は登録できないこと' do
         @item.category_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category is not a number", "Category can't be blank")
+        expect(@item.errors.full_messages).to include('Category is not a number', "Category can't be blank")
       end
 
       it 'categroy_idが1だった場合に登録が出来ないこと' do
         @item.category_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Category must be other than 1")
+        expect(@item.errors.full_messages).to include('Category must be other than 1')
       end
 
       it 'condition_idがない場合は登録できないこと' do
         @item.condition_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition is not a number", "Condition can't be blank")
+        expect(@item.errors.full_messages).to include('Condition is not a number', "Condition can't be blank")
       end
       it 'condition_idが1だった場合に登録が出来ないこと' do
         @item.condition_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Condition must be other than 1")
+        expect(@item.errors.full_messages).to include('Condition must be other than 1')
       end
 
       it 'shipping_fee_idがない場合は登録できないこと' do
         @item.shipping_fee_id = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee is not a number", "Shipping fee can't be blank")
+        expect(@item.errors.full_messages).to include('Shipping fee is not a number', "Shipping fee can't be blank")
       end
       it 'shipping_fee_idが1だった場合に登録が出来ないこと' do
         @item.shipping_fee_id = '1'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Shipping fee must be other than 1")
+        expect(@item.errors.full_messages).to include('Shipping fee must be other than 1')
       end
 
       it 'shipping_days_idがない場合は登録できないこと' do
         @item.shipping_days_id = nil
         @item.valid?
-        expect(@item.errors[:shipping_days_id]).to include("is not a number", "can't be blank")
+        expect(@item.errors[:shipping_days_id]).to include('is not a number', "can't be blank")
       end
       it 'shipping_days_idが1だった場合に登録が出来ないこと' do
         @item.shipping_days_id = '1'
         @item.valid?
-        expect(@item.errors[:shipping_days_id]).to include("must be other than 1")
+        expect(@item.errors[:shipping_days_id]).to include('must be other than 1')
       end
 
       it 'shipping_prefecture_idがない場合は登録できないこと' do
         @item.shipping_prefecture_id = nil
         @item.valid?
-        expect(@item.errors[:shipping_prefecture_id]).to include("is not a number", "can't be blank")
+        expect(@item.errors[:shipping_prefecture_id]).to include('is not a number', "can't be blank")
       end
       it 'shipping_prefecture_idが1だった場合に登録が出来ないこと' do
         @item.shipping_prefecture_id = '1'
         @item.valid?
-        expect(@item.errors[:shipping_prefecture_id]).to include("must be other than 1")
+        expect(@item.errors[:shipping_prefecture_id]).to include('must be other than 1')
       end
       it 'imageがない場合は登録できないこと' do
         @item.image = nil
@@ -97,7 +97,8 @@ RSpec.describe Item, type: :model do
       it 'priceがない場合は登録できないこと' do
         @item.price = nil
         @item.valid?
-        expect(@item.errors[:price]).to include("can't be blank", "is out of setting range", "It is invalid. Price includes double-byte numbers")
+        expect(@item.errors[:price]).to include("can't be blank", 'is out of setting range',
+                                                'It is invalid. Price includes double-byte numbers')
       end
 
       it 'priceが299以下だと登録できないこと' do


### PR DESCRIPTION
# what
商品一覧表示機能の実装について
# why
出品した商品を一覧で表示する為に

尚、「売却済みの商品は、画像上に『sold out』の文字が表示されるようになっていること」という機能に関しては、商品購入機能実装後に実装する予定。現在はコメントアウトしています。

・ログインしていなくても出品している商品は表示できること
https://gyazo.com/9503830541050ba8cc5d514bf54af207
・出品すると新しい商品から表示さ、必要な情報が表示されること
https://gyazo.com/31797fba6cb1253ed75e9d63aa709694

